### PR TITLE
If the translation is not provided, return as-is

### DIFF
--- a/fabric/src/main/java/cn/evole/mods/mcbot/util/locale/I18n.java
+++ b/fabric/src/main/java/cn/evole/mods/mcbot/util/locale/I18n.java
@@ -73,6 +73,11 @@ public class I18n {
     }
 
     public static String get(String key) {
-        return translations.get(key);
+        String translation = translations.get(key);
+        if (translation != null) {
+            return translation;
+        } else {
+            return key;
+        }
     }
 }

--- a/fabric/src/main/java/cn/evole/mods/mcbot/util/onebot/BotUtils.java
+++ b/fabric/src/main/java/cn/evole/mods/mcbot/util/onebot/BotUtils.java
@@ -48,7 +48,7 @@ public class BotUtils {
     public static String varParse(CustomCmd customCmd, String cmd) {
         String returnCmd = "";
         if (isVar(cmd)) {//存在变量
-            val replaceContent = customCmd.getCmdContent().split("%")[0].replaceAll(" ", "");
+            val replaceContent = customCmd.getCmdContent().split("%")[0].trim();
             returnCmd = cmd.replace(customCmd.getCmdAlies(), replaceContent);//返回q群指令
         } else returnCmd = customCmd.getCmdContent();//返回普通自定义命令指令
         return returnCmd;


### PR DESCRIPTION
在未提供翻译的成就或死亡信息中防止出现null，而是使用英文原文。
修复后：
![image](https://github.com/Nova-Committee/McBot/assets/7941967/de1fd1fd-5634-47cf-b024-b8929b71af67)
