### PR TITLE
修复同步消息到QQ时可能的卡顿 [Checked]

### DIFF
--- a/fabric/src/main/java/cn/evole/mods/mcbot/McBot.java
+++ b/fabric/src/main/java/cn/evole/mods/mcbot/McBot.java
@@ -115,6 +115,4 @@ public class McBot implements ModInitializer {
             e.printStackTrace();
         }
     }
-
-
 }


### PR DESCRIPTION
<!-- New Feature or Bug Fix Pull Request -->
<!-- Implement an idea for this project or implement a bug fix to help us improve. -->
<!---->
<!-- Insert "[Enhancement] " or "[Bug] " before the first word in the title. -->
<!-- Note that the PR may be closed directly if you do not follow the instructions. -->

### Checks / 检查

<!-- Please check that you have done the following things before submitting a pull request.在提交请求之前，请检查您是否已完成以下操作。 -->
<!-- Set [ ] to [X] -->

- [X] I confirm that I have [searched for existing issues / pull requests](https://github.com/cnlimiter/McBot/issues?q=) before requesting to avoid duplicate requesting./我确认在报告之前我已经搜索了[现有的问题或者拉取请求](https://github.com/cnlimiter/McBot/issues?q=)，以避免重复报告。
- [X] I confirm that I noted that if I don't follow the instructions, the issue may be closed directly./我确认我已经检查，如果我不按照说明进行操作，该问题可能会被直接关闭。

### Related Issues

<!-- Any GitHub issues related to this PR? If not, please fill in N/A./是否有与此 PR 相关的任何 GitHub 问题？如果没有，请填写NA。 -->
<!-- Example: Fix #ISSUE-NUMBER -->
https://github.com/Nova-Committee/McBot/issues/107
### Description

<!-- For Bug Fix Pull Request: -->
<!-- Please tell us what bug have you fixed with a clear and detailed description, add screenshots to help explain./请告诉我们您修复了哪些错误，并提供清晰详细的描述，并添加截图以帮助解释。 -->
<!---->
在MC发送一条聊天后，服务器主线程会暂停，直到它被同步到QQ。对于玩家的表现是服务器频繁卡顿。

*变更日志*
 - 添加Const.MessageThread作为McBot.bot.sendGuildMsg()的多线程实现。
 - 修改Const.Const.guildMsg()实现。
 - 移除Mcbot.Mcbot中多余的空行。

*对于开发者*
 - 应尽量用Const.MessageThread(args).start()代替McBot.bot.sendGuildMsg(args)，除非你明确知道后果并做好准备。
 - Const.MessageThread的开销会显著高于McBot.bot.sendGuildMsg()。

*已知问题*
 - 服务器无法通过/stop自动退出，你需要在服务器关闭后手动退出，这是安全的。