### PR TITLE
修复同步消息到QQ时可能的卡顿 [Checked]

### DIFF
--- a/fabric/common.gradle
+++ b/fabric/common.gradle
@@ -25,8 +25,8 @@ dependencies {
     modImplementation ("net.fabricmc.fabric-api:fabric-api:${fabric_version}")
     modImplementation include("dev.vankka:dependencydownload-runtime:1.3.1") {exclude module: 'jar-relocator'}
     modImplementation include("dev.vankka:dependencydownload-common:1.3.1")
-    implementation include ("cn.evole.onebot:OneBot-Client:${onebot_client_version}"){transitive = false}
-    implementation include ("cn.evole.config:AtomConfig-Toml:${toml_version}"){transitive = false}
+    implementation ("cn.evole.onebot:OneBot-Client:${onebot_client_version}"){transitive = false}
+    implementation ("cn.evole.config:AtomConfig-Toml:${toml_version}"){transitive = false}
 
     if (mcVersion == 11605) include ("org.slf4j:slf4j-api:2.0.7")
     modCompileOnly ("maven.modrinth:vanish:1.5.2-1.20.1")

--- a/fabric/common.gradle
+++ b/fabric/common.gradle
@@ -25,8 +25,8 @@ dependencies {
     modImplementation ("net.fabricmc.fabric-api:fabric-api:${fabric_version}")
     modImplementation include("dev.vankka:dependencydownload-runtime:1.3.1") {exclude module: 'jar-relocator'}
     modImplementation include("dev.vankka:dependencydownload-common:1.3.1")
-    implementation ("cn.evole.onebot:OneBot-Client:${onebot_client_version}"){transitive = false}
-    implementation ("cn.evole.config:AtomConfig-Toml:${toml_version}"){transitive = false}
+    implementation include ("cn.evole.onebot:OneBot-Client:${onebot_client_version}"){transitive = false}
+    implementation include ("cn.evole.config:AtomConfig-Toml:${toml_version}"){transitive = false}
 
     if (mcVersion == 11605) include ("org.slf4j:slf4j-api:2.0.7")
     modCompileOnly ("maven.modrinth:vanish:1.5.2-1.20.1")

--- a/fabric/src/main/java/cn/evole/mods/mcbot/Const.java
+++ b/fabric/src/main/java/cn/evole/mods/mcbot/Const.java
@@ -1,6 +1,7 @@
 package cn.evole.mods.mcbot;
 
 import cn.evole.mods.mcbot.config.ModConfig;
+import cn.evole.mods.mcbot.util.onebot.MessageThread;
 import net.fabricmc.loader.api.FabricLoader;
 import java.nio.file.Path;
 //#if MC >= 11700
@@ -27,6 +28,7 @@ public class Const {
     public static boolean isShutdown = false;
     public static Path configDir = FabricLoader.getInstance().getConfigDir();
     public static Path gameDir = FabricLoader.getInstance().getGameDir();
+    private static final MessageThread messageThread = new MessageThread();
 
     public static boolean isLoad(String modId){
         return FabricLoader.getInstance().isModLoaded(modId);
@@ -39,11 +41,10 @@ public class Const {
     }
 
     public static void sendGroupMsg(long id, String message){
-        McBot.onebot.getBot().sendGroupMsg(id, message, false);
+        messageThread.submit(id, message, false);
     }
 
-
+    public static void shutdown() {
+        messageThread.stop();
+    }
 }
-
-
-

--- a/fabric/src/main/java/cn/evole/mods/mcbot/McBot.java
+++ b/fabric/src/main/java/cn/evole/mods/mcbot/McBot.java
@@ -9,6 +9,7 @@ import cn.evole.mods.mcbot.init.handler.CustomCmdHandler;
 import cn.evole.mods.mcbot.util.FileUtil;
 import cn.evole.mods.mcbot.util.lib.LibUtils;
 import cn.evole.mods.mcbot.util.locale.I18n;
+import cn.evole.mods.mcbot.util.onebot.CQUtils;
 import cn.evole.onebot.client.OneBotClient;
 import lombok.Getter;
 import net.fabricmc.api.ModInitializer;
@@ -16,8 +17,6 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.minecraft.server.MinecraftServer;
 import java.nio.file.Path;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 //#if MC >= 11900
 //$$ import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 //#else
@@ -40,7 +39,6 @@ public class McBot implements ModInitializer {
     public static McBot INSTANCE = new McBot();
 
     public static OneBotClient onebot;
-    public static ExecutorService CQUtilsExecutor;
 
     @Override
     public void onInitialize() {
@@ -89,7 +87,6 @@ public class McBot implements ModInitializer {
             onebot = OneBotClient.create(ModConfig.INSTANCE.getBotConfig().build()).open().registerEvents(new IBotEvent());
         }
         CustomCmdHandler.INSTANCE.load();//自定义命令加载
-        CQUtilsExecutor = Executors.newSingleThreadExecutor();  // 创建CQ码处理线程池
     }
 
     public void onServerStopping(MinecraftServer server) {
@@ -101,7 +98,8 @@ public class McBot implements ModInitializer {
     }
 
     public void onServerStopped(MinecraftServer server) {
-        CQUtilsExecutor.shutdownNow();
+        Const.shutdown();
+        CQUtils.shutdown();
         if (onebot != null) onebot.close();
     }
 

--- a/fabric/src/main/java/cn/evole/mods/mcbot/util/onebot/CQUtils.java
+++ b/fabric/src/main/java/cn/evole/mods/mcbot/util/onebot/CQUtils.java
@@ -7,10 +7,7 @@ import cn.evole.onebot.sdk.event.message.MessageEvent;
 import lombok.val;
 
 import java.util.Arrays;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.FutureTask;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -26,6 +23,7 @@ public class CQUtils {
 
     private final static String CQ_CODE_REGEX = "\\[CQ:(.*?),(.*?)]";
 
+    private static final ExecutorService Executor = Executors.newSingleThreadExecutor();  // 创建CQ码处理线程池;
 
     public static boolean hasImg(String msg) {
         String regex = "\\[CQ:image,[(\\s\\S)]*]";
@@ -100,7 +98,7 @@ public class CQUtils {
             return message.toString();
         });
         try {
-            McBot.CQUtilsExecutor.execute(call);
+            Executor.execute(call);
             back = call.get(1000 * 3, TimeUnit.MILLISECONDS);
         } catch (ExecutionException | InterruptedException | TimeoutException | IllegalStateException e) {
             back = event.getRawMessage();
@@ -108,5 +106,9 @@ public class CQUtils {
             Const.LOGGER.error(e.getLocalizedMessage());
         }
         return back;
+    }
+
+    public static void shutdown() {
+        Executor.shutdownNow();
     }
 }

--- a/fabric/src/main/java/cn/evole/mods/mcbot/util/onebot/MessageThread.java
+++ b/fabric/src/main/java/cn/evole/mods/mcbot/util/onebot/MessageThread.java
@@ -1,0 +1,44 @@
+package cn.evole.mods.mcbot.util.onebot;
+
+import cn.evole.mods.mcbot.Const;
+import cn.evole.mods.mcbot.McBot;
+import com.google.gson.JsonArray;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * @Project: McBot-fabric
+ * @Author: xia-mc
+ * @CreateTime: 2024/2/12 16:11
+ * @Description: 笑点解析：
+ */
+public class MessageThread {
+    private final ExecutorService executor;
+    public MessageThread() {
+        executor = Executors.newCachedThreadPool();
+    }
+
+    public void submit(long groupId, String msg, boolean autoEscape) {
+        Const.LOGGER.debug(String.format("转发游戏消息: %s", msg));
+        executor.submit(() -> McBot.onebot.getBot().sendGroupMsg(groupId, msg, autoEscape));
+    }
+
+    public void submit(long groupId, JsonArray msg, boolean autoEscape) {
+        Const.LOGGER.debug(String.format("转发游戏消息: %s", msg));
+        executor.submit(() -> McBot.onebot.getBot().sendGroupMsg(groupId, msg, autoEscape));
+    }
+
+    public void submit(String guildID, String channelID, String message) {
+        Const.LOGGER.debug(String.format("转发游戏消息: %s", message));
+        executor.submit(() -> McBot.onebot.getBot().sendGuildMsg(guildID, channelID, message));
+    }
+
+    public void submit(String guildID, String channelID, JsonArray message) {
+        Const.LOGGER.debug(String.format("转发游戏消息: %s", message));
+        executor.submit(() -> McBot.onebot.getBot().sendGuildMsg(guildID, channelID, message));
+    }
+
+    public void stop() {
+        executor.shutdownNow();
+    }
+}


### PR DESCRIPTION
<!-- New Feature or Bug Fix Pull Request -->
<!-- Implement an idea for this project or implement a bug fix to help us improve. -->
<!---->
<!-- Insert "[Enhancement] " or "[Bug] " before the first word in the title. -->
<!-- Note that the PR may be closed directly if you do not follow the instructions. -->

## 检查

<!-- Please check that you have done the following things before submitting a pull request.在提交请求之前，请检查您是否已完成以下操作。 -->
<!-- Set [ ] to [X] -->

- [X] 我确认在报告之前我已经搜索了[现有的问题或者拉取请求](https://github.com/cnlimiter/McBot/issues?q=)，以避免重复报告。
- [X] 我确认我已经检查，如果我不按照说明进行操作，该问题可能会被直接关闭。

## 相关问题/拉取请求

<!-- Any GitHub issues related to this PR? If not, please fill in N/A./是否有与此 PR 相关的任何 GitHub 问题？如果没有，请填写NA。 -->
<!-- Example: Fix #ISSUE-NUMBER -->
https://github.com/Nova-Committee/McBot/issues/107
https://github.com/Nova-Committee/McBot/pull/128
## 描述
<!-- For Bug Fix Pull Request: -->
<!-- Please tell us what bug have you fixed with a clear and detailed description, add screenshots to help explain./请告诉我们您修复了哪些错误，并提供清晰详细的描述，并添加截图以帮助解释。 -->
<!---->
在MC发送一条聊天后，服务器主线程会暂停，直到它被同步到QQ。对于玩家的表现是服务器频繁卡顿。

### 变更日志
 - 添加MessageThread类。
 - 修改Const.sendGuildMsg()实现。
 - 修改一些对象的作用域。

### 对于开发者
 - 无。

### 已知问题
 - 服务器无法通过/stop自动退出，你需要在服务器关闭后手动退出，这是安全的。

## 笑点解析
*孩子们，我回来了。*