### PR TITLE
API 更新（第一部分 补充）

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,30 @@ _✨ 基于 [OneBot](https://github.com/howmanybots/onebot/blob/master/README.md
 ### 使用api进行请求
 
 ```java
-public class TestCmd {
-    public static ArgumentBuilder<CommandSourceStack, ?> register() {
-        return Commands.literal("test")
-                .executes(TestCmd::execute);
+public class APIDemo {
+    static {
+        // 事件回调
+        McBotEvents.ON_CHAT.register((player, msgId, msg) -> System.out.printf("McBot刚刚转发一条消息。由%s发送了%s (%s)%n", player.getName().getString(), msg, msgId));
     }
 
-    public static int execute(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
-        System.out.println(McBot.bot.sendGroupMsg(337631140, MsgUtils.builder().text("1").build(), true));
-        //群里发送消息
-        return 0;
+    /**
+     * 群里发送消息
+     * @param groupId 群号
+     * @param message 消息
+     */
+    public static void doSend(long groupId, String message) throws CommandSyntaxException {
+        Const.sendGroupMsg(groupId, message)
+    }
+
+    /**
+     * 撤回消息
+     * @param message_id 消息ID
+     */
+    public static void recallMessage(int message_id) {
+        JsonObject json = new Gson().fromJson(
+                String.format("{'message_id': %s}", message_id),
+                JsonObject.class);
+        Const.customRequest(ActionType.DELETE_MSG, json);
     }
 }
 ```

--- a/fabric/src/main/java/cn/evole/mods/mcbot/api/McBotEvents.java
+++ b/fabric/src/main/java/cn/evole/mods/mcbot/api/McBotEvents.java
@@ -3,11 +3,12 @@ package cn.evole.mods.mcbot.api;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.server.level.ServerPlayer;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 public class McBotEvents {
     /**
      * 当玩家发送一条消息（并转发到QQ）后触发。
-     * 包含发送消息的玩家和message_id
+     * 包含发送消息的玩家、message_id和消息内容
      */
     public static final Event<PlayerChat> ON_CHAT = EventFactory.createArrayBacked(PlayerChat.class, callbacks -> (player, message_id, message) -> {
         for (PlayerChat callback : callbacks) {
@@ -15,8 +16,24 @@ public class McBotEvents {
         }
     });
 
+    /**
+     * 当玩家发送一条消息后（并在任何处理之前）触发。
+     * 如果取消它，消息将不会发送到游戏和QQ。
+     * 包含发送消息的玩家、消息内容和CallBackInfo。
+     */
+    public static final Event<EarlyPlayerChat> BEFORE_CHAT = EventFactory.createArrayBacked(EarlyPlayerChat.class, callbacks -> (player, message, ci) -> {
+        for (EarlyPlayerChat callback : callbacks) {
+            callback.onChat(player, message, ci);
+        }
+    });
+
     @FunctionalInterface
     public interface PlayerChat {
         void onChat(ServerPlayer player, int message_id, String message);
+    }
+
+    @FunctionalInterface
+    public interface EarlyPlayerChat {
+        void onChat(ServerPlayer player, String message, CallbackInfo ci);
     }
 }

--- a/fabric/src/main/java/cn/evole/mods/mcbot/init/mixins/MixinServerGamePktImpl.java
+++ b/fabric/src/main/java/cn/evole/mods/mcbot/init/mixins/MixinServerGamePktImpl.java
@@ -1,5 +1,6 @@
 package cn.evole.mods.mcbot.init.mixins;
 
+import cn.evole.mods.mcbot.api.McBotEvents;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import org.spongepowered.asm.mixin.Mixin;
 import cn.evole.mods.mcbot.init.callbacks.IEvents;
@@ -24,33 +25,37 @@ public abstract class MixinServerGamePktImpl {
     //#if MC < 11700
     @Shadow
     public ServerPlayer player;
-    @Inject(method = "handleChat(Ljava/lang/String;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/players/PlayerList;broadcastMessage(Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/ChatType;Ljava/util/UUID;)V", shift = At.Shift.BEFORE))
+    @Inject(method = "handleChat(Ljava/lang/String;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/players/PlayerList;broadcastMessage(Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/ChatType;Ljava/util/UUID;)V", shift = At.Shift.BEFORE), cancellable = true)
     public void mcbot$handleChat(String string, CallbackInfo ci) {
-        IEvents.SERVER_CHAT.invoker().onChat(this.player, string);
+        if (!ci.isCancelled()) McBotEvents.BEFORE_CHAT.invoker().onChat(this.player, string, ci);
+        if (!ci.isCancelled()) IEvents.SERVER_CHAT.invoker().onChat(this.player, string);
     }
     //#elseif MC < 11900
     //$$ @Shadow
     //$$ public ServerPlayer player;
-    //$$ @Inject(method = "handleChat(Lnet/minecraft/server/network/TextFilter$FilteredText;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/players/PlayerList;broadcastMessage(Lnet/minecraft/network/chat/Component;Ljava/util/function/Function;Lnet/minecraft/network/chat/ChatType;Ljava/util/UUID;)V", shift = At.Shift.BEFORE))
+    //$$ @Inject(method = "handleChat(Lnet/minecraft/server/network/TextFilter$FilteredText;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/players/PlayerList;broadcastMessage(Lnet/minecraft/network/chat/Component;Ljava/util/function/Function;Lnet/minecraft/network/chat/ChatType;Ljava/util/UUID;)V", shift = At.Shift.BEFORE), cancellable = true)
     //$$ public void mcbot$handleChat(TextFilter.FilteredText filteredText, CallbackInfo ci) {
     //$$     String s1 = filteredText.getRaw();
-    //$$     IEvents.SERVER_CHAT.invoker().onChat(this.player, s1);
+    //$$     if (!ci.isCancelled()) McBotEvents.BEFORE_CHAT.invoker().onChat(this.player, s1, ci);
+    //$$     if (!ci.isCancelled()) IEvents.SERVER_CHAT.invoker().onChat(this.player, s1);
     //$$ }
     //#elseif MC < 11903
     //$$@Shadow
     //$$public ServerPlayer player;
-    //$$@Inject(method = "broadcastChatMessage", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/players/PlayerList;broadcastChatMessage(Lnet/minecraft/network/chat/PlayerChatMessage;Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/network/chat/ChatType$Bound;)V", shift = At.Shift.BEFORE))
+    //$$@Inject(method = "broadcastChatMessage", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/players/PlayerList;broadcastChatMessage(Lnet/minecraft/network/chat/PlayerChatMessage;Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/network/chat/ChatType$Bound;)V", shift = At.Shift.BEFORE), cancellable = true)
     //$$public void mcbot$handleChat(PlayerChatMessage filteredText, CallbackInfo ci) {
     //$$    String s1 = filteredText.serverContent().getString();
-    //$$    IEvents.SERVER_CHAT.invoker().onChat(this.player, s1);
+    //$$    if (!ci.isCancelled()) McBotEvents.BEFORE_CHAT.invoker().onChat(this.player, s1, ci);
+    //$$    if (!ci.isCancelled()) IEvents.SERVER_CHAT.invoker().onChat(this.player, s1);
     //$$}
     //#else
     //$$@Shadow
     //$$public ServerPlayer player;
-    //$$@Inject(method = "broadcastChatMessage", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/players/PlayerList;broadcastChatMessage(Lnet/minecraft/network/chat/PlayerChatMessage;Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/network/chat/ChatType$Bound;)V", shift = At.Shift.BEFORE))
+    //$$@Inject(method = "broadcastChatMessage", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/players/PlayerList;broadcastChatMessage(Lnet/minecraft/network/chat/PlayerChatMessage;Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/network/chat/ChatType$Bound;)V", shift = At.Shift.BEFORE), cancellable = true)
     //$$public void mcbot$handleChat(PlayerChatMessage filteredText, CallbackInfo ci) {
     //$$    String s1 = filteredText.decoratedContent().getString();
-    //$$    IEvents.SERVER_CHAT.invoker().onChat(this.player, s1);
+    //$$    if (!ci.isCancelled()) McBotEvents.BEFORE_CHAT.invoker().onChat(this.player, s1, ci);
+    //$$    if (!ci.isCancelled()) IEvents.SERVER_CHAT.invoker().onChat(this.player, s1);
     //$$}
     //#endif
 

--- a/fabric/src/main/java/cn/evole/mods/mcbot/util/onebot/KeepAlive.java
+++ b/fabric/src/main/java/cn/evole/mods/mcbot/util/onebot/KeepAlive.java
@@ -2,7 +2,6 @@ package cn.evole.mods.mcbot.util.onebot;
 
 import cn.evole.mods.mcbot.Const;
 import cn.evole.mods.mcbot.McBot;
-import cn.evole.mods.mcbot.command.ConnectCommand;
 import cn.evole.mods.mcbot.config.ModConfig;
 import cn.evole.onebot.sdk.event.meta.HeartbeatMetaEvent;
 import lombok.Getter;


### PR DESCRIPTION
# 基本信息
### 检查
- [X] 我确认在报告之前我已经搜索了[现有的问题或者拉取请求](https://github.com/cnlimiter/McBot/issues?q=)，以避免重复报告。
- [X] 我确认我已经检查，如果我不按照说明进行操作，该问题可能会被直接关闭。

# 描述
### 亮点
- 添加一个消息API，当玩家发送消息时触发。
- 修改README部分内容。

### 更改日志
- 添加McBotEvents.BEFORE_CHAT回调。
- 在README 使用api进行请求部分添加一些高级示例。

### 对于开发者
- McBotChatEvents.BEFORE_CHAT (ServerPlayer player, String message, CallbackInfo ci)
    // 发送消息的玩家、原始消息内容、boardcastChatMessage的callbackinfo。
    // 如果执行ci.cancel()，那么McBot不会转发这个消息。其他Mod（也应该）不会发现这条消息。

### 使用例
- #### [光阴：莉拉提娅](https://github.com/xia-mc/TimeRecorder)
    - 消息屏蔽器基于McBotEvents.BEFORE_CHAT实现。