### PR TITLE
Implement new # symbol for QQ binding

### DIFF
--- a/fabric/src/main/java/cn/evole/mods/mcbot/cmds/CmdApi.java
+++ b/fabric/src/main/java/cn/evole/mods/mcbot/cmds/CmdApi.java
@@ -41,16 +41,16 @@ public class CmdApi {
             // 如果指令包含list,则强行以非管理员身份执行
             CustomCmdHandler.INSTANCE.getCustomCmds().stream()
                     .filter(customCmd -> customCmd.getRequirePermission() < 1 && performedCommand.equals(customCmd.getCmdAlies()))
-                    .forEach(customCmd -> GroupCmd(event.getGroupId(), BotUtils.varParse(customCmd, originCommand), false, customCmd.isVanishSupport()));
+                    .forEach(customCmd -> GroupCmd(event.getGroupId(), BotUtils.varParse(customCmd, originCommand, event), false, customCmd.isVanishSupport()));
         }else{
             if (BotUtils.groupAdminParse(event)) {
                 CustomCmdHandler.INSTANCE.getCustomCmds().stream()
                         .filter(customCmd -> performedCommand.equals(customCmd.getCmdAlies()))
-                        .forEach(customCmd -> GroupCmd(event.getGroupId(), BotUtils.varParse(customCmd, originCommand), true, customCmd.isVanishSupport()));//admin
+                        .forEach(customCmd -> GroupCmd(event.getGroupId(), BotUtils.varParse(customCmd, originCommand, event), true, customCmd.isVanishSupport()));//admin
             } else
                 CustomCmdHandler.INSTANCE.getCustomCmds().stream()
                         .filter(customCmd -> customCmd.getRequirePermission() < 1 && performedCommand.equals(customCmd.getCmdAlies()))
-                        .forEach(customCmd -> GroupCmd(event.getGroupId(), BotUtils.varParse(customCmd, originCommand), false, customCmd.isVanishSupport()));
+                        .forEach(customCmd -> GroupCmd(event.getGroupId(), BotUtils.varParse(customCmd, originCommand, event), false, customCmd.isVanishSupport()));
         }
 
     }

--- a/fabric/src/main/java/cn/evole/mods/mcbot/util/onebot/BotUtils.java
+++ b/fabric/src/main/java/cn/evole/mods/mcbot/util/onebot/BotUtils.java
@@ -26,7 +26,7 @@ public class BotUtils {
         AtomicBoolean match = new AtomicBoolean(false);
         CustomCmdHandler.INSTANCE.getCustomCmds().forEach(
                 cmd -> {
-                    if (cmd.getCmdContent().contains("%")) {//是否变量模板
+                    if (cmd.getCmdContent().contains("%") | cmd.getCmdContent().contains("#")) {//是否变量模板
                         if (msg.contains(cmd.getCmdAlies()))//去除命令符号
                             match.set(true);
                     }
@@ -43,11 +43,12 @@ public class BotUtils {
      * @param cmd       q群指令
      * @return 处理完的指令
      */
-    public static String varParse(CustomCmd customCmd, String cmd) {
+    public static String varParse(CustomCmd customCmd, String cmd, GroupMessageEvent event) {
         String returnCmd = "";
         if (isVar(cmd)) {//存在变量
             val replaceContent = customCmd.getCmdContent().split("%")[0].trim();
             returnCmd = cmd.replace(customCmd.getCmdAlies(), replaceContent);//返回q群指令
+            returnCmd = returnCmd.replace("#", event.getSender().getUserId());
         } else returnCmd = customCmd.getCmdContent();//返回普通自定义命令指令
         return returnCmd;
     }


### PR DESCRIPTION
新功能实施：
使用#号作为群ID的占位符，#会被替换成玩家的QQ号。
这允许群服互联在不要求玩家绑定的情况下，进行简单的鉴权。
例如：命令格式buy # %
聊天：`!buy 石头 `
会在游戏中替换成`/buy QQ号 石头`。
